### PR TITLE
#4 update depth recorder service for deployment specific output directories

### DIFF
--- a/service.nix
+++ b/service.nix
@@ -32,7 +32,7 @@ in {
         #!/usr/bin/env bash
         set -x
         # DEPLOYMENT_DIRECTORY is set by the deployment-start service
-        OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.audio-recorder.output-folder}
+        OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.depth-recorder.output-folder}
         ${pkgs.coreutils}/bin/mkdir -p $OUTPUT_PATH
         RUST_LOG=info ${depthRecorder}/bin/depth-recorder \
         $OUTPUT_PATH \

--- a/service.nix
+++ b/service.nix
@@ -10,7 +10,7 @@ in {
     services.depth-recorder = {
       enable = lib.mkEnableOption "Whether to enable the depth-recorder service.";
 
-      output-path = lib.mkOption {
+      output-folder = lib.mkOption {
         type = lib.types.str;
         default = "depth";
         description = "The folder to save recordings to within the deployment directory.";

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn calculate_depth(adc_value: i16) -> (f32, f32, f32) {
 }
 
 fn init_csv_writer(output_path: PathBuf) -> csv::Writer<File> {
-    let filename = format!("{}_depth_data.csv", Utc::now().format("%Y-%m-%dT%H-%M-%S"));
+    let filename = format!("{}_depth_data.csv", Utc::now().format("%Y-%m-%dT%H_%M_%S%z"));
     let file_path = output_path.join(filename);
     info!("Writing depth data to {}", file_path.display());
     let file = OpenOptions::new()


### PR DESCRIPTION
This PR updates depth-recorder service output path creation.

Previously, the absolute path to the data-specific directory was passed through the `output-path` option of the service (`/output/depth`). Now, the service reads `DEPLOYMENT_DIRECTORY` environment variable and appends to that the value of `output-folder` option. `output-folder` now designates the folder to be created within the deployment specific output directory where gps data should be written to. Default value for `output-folder` is `depth`.

Also, the output file name format is updated to `%Y-%m-%dT%H_%M_%S%z`, updating delimiters and adding time zone information.

Closes #4 